### PR TITLE
[Cow] Fix Fee USD

### DIFF
--- a/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
@@ -119,12 +119,7 @@ BEGIN
                        fee,
                        fee_atoms,
                        (CASE
-                            WHEN sell_price IS NOT NULL THEN
-                                CASE
-                                    WHEN buy_price IS NOT NULL and buy_price * units_bought > sell_price * units_sold
-                                        then buy_price * units_bought * fee / units_sold
-                                    ELSE sell_price * fee
-                                    END
+                            WHEN sell_price IS NOT NULL THEN sell_price * fee
                             WHEN sell_price IS NULL AND buy_price IS NOT NULL
                                 THEN buy_price * units_bought * fee / units_sold
                             ELSE NULL::numeric

--- a/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
@@ -120,6 +120,11 @@ BEGIN
                        fee_atoms,
                        (CASE
                             WHEN sell_price IS NOT NULL THEN sell_price * fee
+                           -- Note that this formulation is subject to some precision error in a few irregular cases:
+                           -- E.g. In this transaction 0x84d57d1d57e01dd34091c763765ddda6ff713ad67840f39735f0bf0cced11f02
+                           -- buy_price * units_bought * fee / units_sold
+                           -- 1.001076 * 0.005 * 0.0010148996324193 / 3e-18 = 1693319440706.3
+                           -- So, if sell_price had been null here (thankfully it is not), we would have a vastly inaccurate fee valuation
                             WHEN buy_price IS NOT NULL THEN buy_price * units_bought * fee / units_sold
                             ELSE NULL::numeric
                         END)                                           as fee_usd,

--- a/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
@@ -120,7 +120,7 @@ BEGIN
                        fee_atoms,
                        (CASE
                             WHEN sell_price IS NOT NULL THEN sell_price * fee
-                           -- Note that this formulation is subject to some precision error in a few irregular cases:
+                           -- Note that this formulation is subject to some precision error in a few irregular cases: 
                            -- E.g. In this transaction 0x84d57d1d57e01dd34091c763765ddda6ff713ad67840f39735f0bf0cced11f02
                            -- buy_price * units_bought * fee / units_sold
                            -- 1.001076 * 0.005 * 0.0010148996324193 / 3e-18 = 1693319440706.3
@@ -207,43 +207,43 @@ SELECT gnosis_protocol_v2.insert_trades(
            )
            ;
 
--- For the two cron jobs defined below,
--- one is intended to back fill lagging price feed (while also including most recent trades).
--- The second, less frequent job is meant to back fill missing token data that is manually
--- updated on an irregular schedule. A three month time window should suffice for manual token updates.
+-- -- For the two cron jobs defined below,
+-- -- one is intended to back fill lagging price feed (while also including most recent trades).
+-- -- The second, less frequent job is meant to back fill missing token data that is manually
+-- -- updated on an irregular schedule. A three month time window should suffice for manual token updates.
 
--- Every five minutes we go back 1 day and repopulate the values.
--- This captures new trades since the previous run, but also includes
--- previously non-existent price data (since the price feed is slightly behind)
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/5 * * * *', $$
-    BEGIN;
-    DELETE FROM gnosis_protocol_v2.trades
-        WHERE block_time >= (SELECT DATE_TRUNC('day', now()) - INTERVAL '1 days');
-    SELECT gnosis_protocol_v2.insert_trades(
-        (SELECT DATE_TRUNC('day', now()) - INTERVAL '1 days')
-    );
-    COMMIT;
-$$)
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- -- Every five minutes we go back 1 day and repopulate the values.
+-- -- This captures new trades since the previous run, but also includes
+-- -- previously non-existent price data (since the price feed is slightly behind)
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/5 * * * *', $$
+--     BEGIN;
+--     DELETE FROM gnosis_protocol_v2.trades
+--         WHERE block_time >= (SELECT DATE_TRUNC('day', now()) - INTERVAL '1 days');
+--     SELECT gnosis_protocol_v2.insert_trades(
+--         (SELECT DATE_TRUNC('day', now()) - INTERVAL '1 days')
+--     );
+--     COMMIT;
+-- $$)
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 
--- Once per day we go back 3 months repopulate the values.
--- This is intended to back fill any new erc20 token data that may have been introduced.
--- While simultaneously updating all fields relying on token data. Specifically, these are:
--- buy_token, sell_token, (for the symbol) and
--- trade_value_usd, units_bought, units_sold, sell_price, buy_price, fee, fee_usd (requiring token decimals).
---
--- NOTE that we choose to run this job daily at 1 minute past midnight,
--- so not to compete with the every 5 minute job above
-INSERT INTO cron.job (schedule, command)
-VALUES ('1 0 * * *', $$
-    BEGIN;
-    DELETE FROM gnosis_protocol_v2.trades
-        WHERE block_time >= (SELECT DATE_TRUNC('day', now()) - INTERVAL '3 months');
-    SELECT gnosis_protocol_v2.insert_trades(
-        (SELECT DATE_TRUNC('day', now()) - INTERVAL '3 months')
-    );
-    COMMIT;
-$$)
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- -- Once per day we go back 3 months repopulate the values.
+-- -- This is intended to back fill any new erc20 token data that may have been introduced.
+-- -- While simultaneously updating all fields relying on token data. Specifically, these are:
+-- -- buy_token, sell_token, (for the symbol) and
+-- -- trade_value_usd, units_bought, units_sold, sell_price, buy_price, fee, fee_usd (requiring token decimals).
+-- --
+-- -- NOTE that we choose to run this job daily at 1 minute past midnight,
+-- -- so not to compete with the every 5 minute job above
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('1 0 * * *', $$
+--     BEGIN;
+--     DELETE FROM gnosis_protocol_v2.trades
+--         WHERE block_time >= (SELECT DATE_TRUNC('day', now()) - INTERVAL '3 months');
+--     SELECT gnosis_protocol_v2.insert_trades(
+--         (SELECT DATE_TRUNC('day', now()) - INTERVAL '3 months')
+--     );
+--     COMMIT;
+-- $$)
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 COMMIT;

--- a/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/gnosis_protocol_v2/insert_trades.sql
@@ -120,10 +120,9 @@ BEGIN
                        fee_atoms,
                        (CASE
                             WHEN sell_price IS NOT NULL THEN sell_price * fee
-                            WHEN sell_price IS NULL AND buy_price IS NOT NULL
-                                THEN buy_price * units_bought * fee / units_sold
+                            WHEN buy_price IS NOT NULL THEN buy_price * units_bought * fee / units_sold
                             ELSE NULL::numeric
-                           END)                                        as fee_usd,
+                        END)                                           as fee_usd,
                        app_data,
                        CONCAT('\x', substring(receiver from 3))::bytea as receiver
                 FROM trades_with_token_units

--- a/deprecated-dune-v1-abstractions/xdai/gnosis_protocol_v2/view_trades.sql
+++ b/deprecated-dune-v1-abstractions/xdai/gnosis_protocol_v2/view_trades.sql
@@ -1090,8 +1090,8 @@ CREATE INDEX view_trades_idx_4 ON gnosis_protocol_v2.view_trades (trader);
 CREATE INDEX view_trades_idx_6 ON gnosis_protocol_v2.view_trades (tx_hash);
 
 
-INSERT INTO cron.job (schedule, command)
-VALUES ('*/30 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol_v2.view_trades')
-ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
+-- INSERT INTO cron.job (schedule, command)
+-- VALUES ('*/30 * * * *', 'REFRESH MATERIALIZED VIEW CONCURRENTLY gnosis_protocol_v2.view_trades')
+-- ON CONFLICT (command) DO UPDATE SET schedule=EXCLUDED.schedule;
 
 COMMIT;

--- a/deprecated-dune-v1-abstractions/xdai/gnosis_protocol_v2/view_trades.sql
+++ b/deprecated-dune-v1-abstractions/xdai/gnosis_protocol_v2/view_trades.sql
@@ -1053,16 +1053,12 @@ valued_trades as (
                 WHEN sell_price IS NOT NULL THEN
                     CASE
                         -- Units sold is sometimes zero we add this
-                        WHEN units_sold = 0
-                            THEN 0
-                        WHEN buy_price IS NOT NULL AND buy_price * units_bought > sell_price * units_sold
-                            THEN buy_price * units_bought * fee / units_sold
-                        ELSE sell_price * fee
-                        END
-                WHEN sell_price IS NULL AND buy_price IS NOT NULL
-                    THEN buy_price * units_bought * fee / units_sold
+                        WHEN units_sold = 0 THEN 0
+                        WHEN sell_price IS NOT NULL THEN sell_price * fee
+                    END
+                WHEN buy_price IS NOT NULL THEN buy_price * units_bought * fee / units_sold
                 ELSE NULL::numeric
-               END)                 as fee_usd
+           END)                 as fee_usd
     FROM trades_with_token_units
 )
 


### PR DESCRIPTION
We recently discovered a HUGE precision/rounding error on the calculation of `fee_usd` in the case when sell_price is not null. Since the fees are taken in sell token, there is no reason for us to try to take the larger of the two. here.

That is, when sell_price is not null, then  is `fee_usd = sell_price * fee`.

cc @josojo for internal approval


This Trade is causing the problem:

```sql
select * from gnosis_protocol_v2.trades
where tx_hash = '\x84d57d1d57e01dd34091c763765ddda6ff713ad67840f39735f0bf0cced11f02'
```

Analogous PR has been made to the spellbook [here](https://github.com/duneanalytics/spellbook/pull/2422)