### PR TITLE
fix null bpt prices on balancer trades

### DIFF
--- a/deprecated-dune-v1-abstractions/ethereum/dex/trades/insert_balancer.sql
+++ b/deprecated-dune-v1-abstractions/ethereum/dex/trades/insert_balancer.sql
@@ -124,6 +124,7 @@ WITH rows AS (
             FROM balancer_v2.view_bpt_prices
             WHERE hour <= dexs.block_time
             AND contract_address = dexs.token_b_address
+            AND median_price IS NOT NULL
         )
         AND bpa.hour >= start_ts
         AND bpa.hour < end_ts
@@ -133,6 +134,7 @@ WITH rows AS (
             FROM balancer_v2.view_bpt_prices
             WHERE hour <= dexs.block_time
             AND contract_address = dexs.token_b_address
+            AND median_price IS NOT NULL
         )
         AND bpb.hour >= start_ts
         AND bpb.hour < end_ts


### PR DESCRIPTION
We noticed Balancer `dex.trades` is missing some volume due to null BPT prices. Because a lot of users still look into the DEX metrics dashboard (which is on V1) we decided to fix this abstraction but I will push the definitive fix to the spellbook shortly as well. Besides that, I know abstractions have been deprecated so not sure if this is possible but I would appreciate it if you could re-run `dex.trades` for Balancer is the last 7 days so DEX metrics look better.